### PR TITLE
Fix/projects nav scroll

### DIFF
--- a/client/src/components/projects/overlay.jsx
+++ b/client/src/components/projects/overlay.jsx
@@ -14,16 +14,17 @@ export function toSafeId(v, fb) {
 }
 
 /* ------------------------- PRESENTATIONAL OVERLAY ------------------------ */
-export default function Overlay({ step, arrived, slides, onWheelStep }) {
+export default function Overlay({ step, arrived, slides, onWheelStep, stopsLength }) {
 	const containerRef = useRef(null)
 	const cooldown = useRef(0)
 
 	const len = Array.isArray(slides) ? slides.length : 0
-	const safeIndex = len > 0 ? ((step % len) + len) % len : 0
+	const effectiveLen = stopsLength ? Math.min(len, stopsLength) : len
+	const safeIndex = effectiveLen > 0 ? ((step % effectiveLen) + effectiveLen) % effectiveLen : 0
 
 	useEffect(() => {
 		const el = containerRef.current
-		if (!el || !len) return
+		if (!el || !effectiveLen) return
 
 		const COOLDOWN_MS = 150
 		const now = () => performance.now()
@@ -36,10 +37,10 @@ export default function Overlay({ step, arrived, slides, onWheelStep }) {
 			if (!dir) return
 
 			const atFirst = step <= 0
-			const atLast = step >= len - 1
+			const atLast = step >= effectiveLen - 1
 			let delta = 0
-			if (dir > 0) delta = atLast ? -(len - 1) : 1
-			else delta = atFirst ? (len - 1) : -1
+			if (dir > 0) delta = atLast ? -(effectiveLen - 1) : 1
+			else delta = atFirst ? (effectiveLen - 1) : -1
 
 			onWheelStep(delta)
 			cooldown.current = t + COOLDOWN_MS
@@ -83,10 +84,10 @@ export default function Overlay({ step, arrived, slides, onWheelStep }) {
 			if (Math.abs(dy) >= SWIPE_THRESHOLD) {
 				const dir = Math.sign(-dy)
 				const atFirst = step <= 0
-				const atLast = step >= len - 1
+				const atLast = step >= effectiveLen - 1
 				let delta = 0
-				if (dir > 0) delta = atLast ? -(len - 1) : 1
-				else if (dir < 0) delta = atFirst ? (len - 1) : -1
+				if (dir > 0) delta = atLast ? -(effectiveLen - 1) : 1
+				else if (dir < 0) delta = atFirst ? (effectiveLen - 1) : -1
 
 				if (delta !== 0) {
 					onWheelStep(delta)
@@ -106,7 +107,7 @@ export default function Overlay({ step, arrived, slides, onWheelStep }) {
 			el.removeEventListener("touchmove", onTouchMove)
 			el.removeEventListener("touchend", onTouchEnd)
 		}
-	}, [onWheelStep, step, len])
+	}, [onWheelStep, step, effectiveLen])
 
 	const slide = len ? slides[safeIndex] : null
 
@@ -123,7 +124,7 @@ export default function Overlay({ step, arrived, slides, onWheelStep }) {
 		>
 			<div className="w-full max-w-3xl px-6">
 				<div className="flex items-center justify-between text-xs uppercase tracking-widest opacity-70 mb-1">
-					<span className="font-semibold">Step {len ? safeIndex + 1 : 0} / {len}</span>
+					<span className="font-semibold">Step {effectiveLen ? safeIndex + 1 : 0} / {effectiveLen}</span>
 					<span className="font-semibold">Scroll / Swipe to navigate</span>
 				</div>
 
@@ -202,6 +203,7 @@ export function ConnectedProjectsOverlay({
 	step,
 	arrived,
 	onWheelStep,
+	stopsLength,
 	query = {},
 	initialFocusKey = "",
 	onResolveFocusIndex,
@@ -219,7 +221,12 @@ export function ConnectedProjectsOverlay({
 		if (!slides.length) return
 		const key = String(initialFocusKey || "").toLowerCase().trim()
 		if (!key) return
-		const idx = slides.findIndex((s) => s._match?.some((m) => m === key))
+		const idx = slides.findIndex((s) => {
+			const candidates = [s?._id, s?.slug, s?.id, s?.title, toSafeId(s?.title)]
+				.filter(Boolean)
+				.map((v) => String(v).toLowerCase())
+			return candidates.includes(key)
+		})
 		if (idx >= 0) {
 			didResolveRef.current = true
 			onResolveFocusIndex?.(idx)
@@ -232,6 +239,7 @@ export function ConnectedProjectsOverlay({
 			arrived={arrived}
 			slides={slides}
 			onWheelStep={onWheelStep}
+			stopsLength={stopsLength}
 		/>
 	)
 }

--- a/client/src/components/projects/slugify.js
+++ b/client/src/components/projects/slugify.js
@@ -1,0 +1,11 @@
+export function toSlug(v, fb) {
+	const s = (v ?? fb ?? "").toString().toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "")
+	return s || (fb?.toString?.() ?? "")
+}
+
+export function buildProjectPath(slide) {
+	const slug = toSlug(slide?.title, slide?._id)
+	return `/projects/${slug}`
+}

--- a/client/src/pages/projectdetails.jsx
+++ b/client/src/pages/projectdetails.jsx
@@ -1,0 +1,110 @@
+// tabs only
+import React, { useMemo } from "react"
+import { useParams, Link, useNavigate } from "react-router-dom"
+import { useProjects } from "../lib/useProjects"
+import { toSlug } from "../components/projects/slugify"
+import { motion } from "framer-motion"
+
+export default function ProjectDetails() {
+	const { slug } = useParams()
+	const navigate = useNavigate()
+	const { data: all = [], error, isLoading } = useProjects({ limit: 100, sort: "-date" })
+
+	const project = useMemo(() => {
+		if (!slug || !all.length) return null
+		let p = all.find((s) => toSlug(s?.title, s?._id) === slug)
+		if (!p) p = all.find((s) => s?._id?.toString?.() === slug)
+		return p ?? null
+	}, [slug, all])
+
+	if (isLoading) return <div className="min-h-[60vh] grid place-items-center opacity-70">Loading…</div>
+
+	if (error) {
+		return (
+			<div className="max-w-3xl mx-auto px-4 py-10">
+				<p className="text-red-400">Failed to load project.</p>
+				<button onClick={() => navigate(-1)} className="underline opacity-80 hover:opacity-100">Go back</button>
+			</div>
+		)
+	}
+
+	if (!project) {
+		return (
+			<div className="max-w-3xl mx-auto px-4 py-10">
+				<h1 className="text-2xl font-semibold mb-2">Project not found</h1>
+				<p className="opacity-80 mb-6">No project for: <span className="font-mono">{slug}</span></p>
+				<button onClick={() => navigate(-1)} className="inline-flex px-3 py-1.5 rounded border border-white/20 hover:bg-white/10">Go back</button>
+			</div>
+		)
+	}
+
+	const description = project?.description ?? project?.body ?? ""
+	const skills = Array.isArray(project?.skills) ? project.skills : []
+	const features = Array.isArray(project?.features) ? project.features : []
+	const links = Array.isArray(project?.links) ? project.links : []
+
+	return (
+		<div className="max-w-3xl mx-auto px-4 py-8">
+			<div className="flex items-center justify-between mb-4">
+				<button onClick={() => navigate(-1)} className="inline-flex text-sm opacity-80 hover:opacity-100">← Back</button>
+				<Link to="/projects" className="inline-flex text-sm opacity-70 hover:opacity-100">All projects</Link>
+			</div>
+
+			<motion.div
+				initial={{ opacity: 0, y: 12 }}
+				animate={{ opacity: 1, y: 0 }}
+				transition={{ duration: 0.35, ease: "easeOut" }}
+				className="rounded-2xl p-5 backdrop-blur bg-black/20 border border-white/10 shadow-xl"
+			>
+				<h1 className="text-3xl font-semibold mb-2">{project.title}</h1>
+
+				{(project.dateLabel || project.associated) && (
+					<div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-white/80 mb-4">
+						{project.dateLabel && <span className="whitespace-nowrap">{project.dateLabel}</span>}
+						{project.dateLabel && project.associated && <span className="opacity-50">•</span>}
+						{project.associated && <span className="whitespace-nowrap">{project.associated}</span>}
+					</div>
+				)}
+
+				{description && <p className="text-base leading-relaxed opacity-90 mb-4">{description}</p>}
+
+				{skills.length > 0 && (
+					<div className="mb-4">
+						<div className="text-xs uppercase tracking-widest opacity-70 mb-2">Skills</div>
+						<div className="flex flex-wrap gap-2">
+							{skills.map((s, i) => (
+								<span key={i} className="text-xs px-2 py-1 rounded-full bg-white/10 border border-white/10">{s}</span>
+							))}
+						</div>
+					</div>
+				)}
+
+				{features.length > 0 && (
+					<div className="mb-4">
+						<div className="text-xs uppercase tracking-widest opacity-70 mb-2">Features</div>
+						<ul className="list-disc list-inside space-y-1 text-base opacity-90">
+							{features.map((f, i) => (<li key={i}>{f}</li>))}
+						</ul>
+					</div>
+				)}
+
+				{links.length > 0 && (
+					<div className="pt-2 flex flex-wrap gap-2">
+						{links.map((l, i) => (
+							<a
+								key={i}
+								href={l.href}
+								target="_blank"
+								rel="noreferrer"
+								className="inline-flex items-center gap-2 text-sm px-3 py-1.5 rounded-full border border-white/15 bg-white/10 hover:bg-white/15 transition"
+								title={l.href}
+							>
+								{l.label}
+							</a>
+						))}
+					</div>
+				)}
+			</motion.div>
+		</div>
+	)
+}

--- a/client/src/pages/projectspage.jsx
+++ b/client/src/pages/projectspage.jsx
@@ -1,5 +1,6 @@
 // src/pages/RoomShowcase.jsx
 import React, { useMemo, useState, useCallback } from "react"
+import { useSearchParams } from "react-router-dom"
 import { Canvas } from "@react-three/fiber"
 import Navbar from "../components/home/utils/navbar.jsx"
 import { CameraRig, RoomModel, SceneLights } from "../components/projects/index.jsx"
@@ -8,10 +9,9 @@ import { getScene } from "../db/projectData.js"
 import GlobalLoader from '/src/components/comm/loader.jsx'
 
 function useFocusKey() {
-	if (typeof window === 'undefined') return ''
-	const sp = new URLSearchParams(window.location.search)
-	const q = sp.get('focus') || ''
-	const h = (window.location.hash || '').replace(/^#/, '')
+	const [params] = useSearchParams()
+	const q = params.get('focus') || ''
+	const h = (typeof window !== 'undefined' ? window.location.hash : '').replace(/^#/, '')
 	return (q || h || '').toLowerCase()
 }
 

--- a/client/src/sections/projects.jsx
+++ b/client/src/sections/projects.jsx
@@ -1,5 +1,6 @@
 // src/components/projects/Projects.jsx
 import React, { useMemo } from 'react'
+import { Link } from 'react-router-dom'
 import { useProjects } from '../lib/useProjects.jsx'
 
 const FEATURED = (import.meta.env.VITE_FEATURED || '')
@@ -28,8 +29,8 @@ function Skeleton() {
 
 function ProjectCard({ title, desc, href }) {
 	return (
-		<a
-			href={href}
+		<Link
+			to={href}
 			className="group block rounded-xl border border-white/10 bg-white/5 p-5 transition
 			        	hover:bg-white/10 hover:border-white/20 hover:shadow-md
 			        	focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40"
@@ -46,7 +47,7 @@ function ProjectCard({ title, desc, href }) {
 					<path d="M5 12h14M13 5l7 7-7 7" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/>
 				</svg>
 			</div>
-		</a>
+		</Link>
 	)
 }
 
@@ -115,8 +116,8 @@ export default function Projects() {
 			)}
 
 			<div className="mt-6 flex justify-end">
-				<a
-					href="/projects"
+				<Link
+					to="/projects"
 					className="inline-flex items-center gap-2 text-sm font-medium opacity-90 hover:opacity-100
 					        	border border-white/10 rounded-xl px-4 py-2 bg-white/5 hover:bg-white/10 transition"
 					aria-label="View all projects"
@@ -125,7 +126,7 @@ export default function Projects() {
 					<svg width="16" height="16" viewBox="0 0 24 24" fill="none" className="stroke-white/90">
 						<path d="M5 12h14M13 5l7 7-7 7" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/>
 					</svg>
-				</a>
+				</Link>
 			</div>
 		</section>
 	)


### PR DESCRIPTION
Summary                                                                                                                                                                                                            
                                                                                                                                                                                                                     
  - Scroll range now adapts to project count — stopsLength was passed to ConnectedProjectsOverlay but never forwarded; navigation was hardcoded to 9 camera stops regardless of how many projects exist. Now uses    
  min(projectCount, cameraStops) as the effective bound, so adding or removing projects automatically adjusts the scroll range.
  - Project anchor links from home page were completely broken — ConnectedProjectsOverlay searched s._match to resolve a focused project, but that field never exists on raw Mongoose .lean() documents. The
  findIndex always returned -1 and the camera never jumped. Fixed by matching directly against _id, slug, id, title, and slugified title.
  - Navigating from home → specific project caused a blank screen — Project cards and the "View all" link used plain <a href>, triggering a full page reload. This re-ran GlobalLoader which blocked the entire UI
  waiting for window.load (including re-downloading the 3D model). Switched to React Router <Link> for client-side navigation. Also replaced the window.location.search read in useFocusKey with useSearchParams() so
   the focus param is always read from Router state correctly.

  Files changed

  - client/src/components/projects/overlay.jsx
  - client/src/pages/projectspage.jsx
  - client/src/sections/projects.jsx